### PR TITLE
Build ser2tcp as a universal binary

### DIFF
--- a/tools/ser2tcp/eg_c/Makefile
+++ b/tools/ser2tcp/eg_c/Makefile
@@ -23,10 +23,29 @@ STAPP=sertest$(EXT)
 
 CFLAGS=$(OPT) -Wall -Wextra -pedantic -std=gnu17
 
-all: $(APP)
+TARGETS:=$(APP)
+
+ifeq ($(XOS),Darwin)
+  CFLAGS+= -target x86_64-apple-macos11
+  TARGETS:=universal
+  ARMAPP:=$(APP).arm64
+  APP:=$(APP).x64
+endif
+
+
+
+all: $(TARGETS)
 
 $(APP): ser2tcp.c serial.c find_best.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
+
+
+$(APP).arm64: ser2tcp.c serial.c find_best.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)  -target arm64-apple-macos11
+
+universal: $(APP) $(ARMAPP)
+	lipo -create -output ser2tcp $^
+
 
 static: ser2tcp.c serial.c find_best.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $(APP) $(STATIC) $^ $(LIBS)
@@ -39,4 +58,4 @@ install: $(APP)
 	install -s -m 755 $(APP) $(prefix)/bin/
 
 clean:
-	rm -f *.o *.exe ser2tcp sertest ~*
+	rm -f *.o *.exe ser2tcp sertest ser2tcp *.swp *~

--- a/tools/ser2tcp/eg_c/Makefile
+++ b/tools/ser2tcp/eg_c/Makefile
@@ -40,7 +40,7 @@ $(APP): ser2tcp.c serial.c find_best.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)
 
 
-$(APP).arm64: ser2tcp.c serial.c find_best.c
+$(ARMAPP): ser2tcp.c serial.c find_best.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ $(LIBS)  -target arm64-apple-macos11
 
 universal: $(APP) $(ARMAPP)


### PR DESCRIPTION
My Makefile fu is a bit rusty, but I believe this gets the job done.

Also, clean had rm ~*, Was that a typo for *~?